### PR TITLE
Fix ADC 8-15

### DIFF
--- a/firmware/arduino_mega2560/m2560/hwconfig.h
+++ b/firmware/arduino_mega2560/m2560/hwconfig.h
@@ -79,12 +79,16 @@ static void inline ADC_init(void)
 		(1 << ADPS2) | (1 << ADPS1) | (1 << ADPS0); // prescaler 128x
 }
 
+// https://ww1.microchip.com/downloads/en/devicedoc/atmel-2549-8-bit-avr-microcontroller-atmega640-1280-1281-2560-2561_datasheet.pdf
+// page 266 : 25.2.1
+#define ADCSRB_MUX5 3
+
 static void inline ADC_setmux(uint8_t mux)
 {
 	ADMUX &= ~0x1F;
 	ADMUX |= mux & 0x1F;
-	ADCSRB &= ~(1 << MUX5);
-	ADCSRB |= (((mux >> 5) & 0x01) << MUX5);
+	ADCSRB &= ~(1 << ADCSRB_MUX5);
+	ADCSRB |= (((mux >> 5) & 0x01) << ADCSRB_MUX5);
 }
 
 #endif

--- a/firmware/arduino_mega2560/m2560/pinmap.h
+++ b/firmware/arduino_mega2560/m2560/pinmap.h
@@ -100,7 +100,7 @@
 
 
 	// (port, pin, mux, value_min, value_max, joyid, axis
-	// for mega2560, mux is 0x00..0x07 => (ADC0..ADC7) and 0x10..0x17 => (ADC8..ADC15)
+	// for mega2560, mux is 0x00..0x07 => (ADC0..ADC7) and 0x20..0x27 => (ADC8..ADC15)
 #define ADC_MAPPING_TABLE(_map_) \
 	\
 	_map_( F, 2, 0x02, 0.000, 1.000, ID_Joystick2, 0 ) /* Analog Pin 2 */ \


### PR DESCRIPTION
ADC8..ADC15 in pinmap.h for mega2560 did not work.
The MUX5 bit was not set correctly.